### PR TITLE
fix(Security): code scanning alert no. 1: Overly permissive regular expression range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2672,9 +2672,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
+      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/src/app/home/[categorie]/[challenge]/actions.tsx
+++ b/src/app/home/[categorie]/[challenge]/actions.tsx
@@ -97,7 +97,7 @@ function checkBlacklist(content: string): string {
 
 function getErrorPositionsFromErrormessage(errormessage: string) {
     const errorLines:{[key: string]: number[]} = {};
-    const regex = /([aA0-zZ9]+)\.java:\[(\d+),(\d+)]/gm
+    const regex = /([a-zA-Z0-9]+)\.java:\[(\d+),(\d+)]/gm
 
     const matches = [...errormessage.matchAll(regex)];
 


### PR DESCRIPTION
Fixes [https://github.com/JavaChallenges/Interface/security/code-scanning/1](https://github.com/JavaChallenges/Interface/security/code-scanning/1)

To fix the problem, we need to update the regular expression to use a more precise character range that matches only the intended characters. Specifically, we should replace the range `0-z` with `0-9a-zA-Z` to ensure that only alphanumeric characters are matched. This change will prevent the regular expression from matching unintended punctuation characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
